### PR TITLE
Adds error scope for log handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 
 # Virtual environments
 venv
+Pipfile
+Pipfile.lock
 
 # JSON tokens
 gradder_cred.json

--- a/app/logger.py
+++ b/app/logger.py
@@ -83,6 +83,32 @@ class logger:
         log.warning(message)
 
     @staticmethod
+    def error(message):
+        from flask_login import current_user
+
+        if current_user.is_authenticated:
+            file_handler = logging.FileHandler(
+                f"./app/logs/{current_user.USERTYPE.lower()}_actions.log", mode="a+"
+            )
+            file_handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s - {} - {} - %(funcName)s - line %(lineno)d".format(
+                        current_user.email, current_user.USERTYPE
+                    )
+                )
+            )
+        else:
+            file_handler = logging.FileHandler("./app/logs/user_actions.log", mode="a+")
+            file_handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s - %(name)s - %(levelname)s - %(message)s - %(funcName)s - line %(lineno)d"
+                )
+            )
+        
+        log.addHandler(file_handler)
+        log.error(message)
+
+    @staticmethod
     def critical(message):
         from flask_login import current_user
 


### PR DESCRIPTION
Also adds Pipfile and Pipfile.lock to .gitignore (alongside venv). This fixes the issue that arises in `/app/modules/admin/routes.py` (and possibly other places) when trying to log a non-exception error:
```python
Traceback (most recent call last):
  File "/env/lib/python3.6/site-packages/flask/app.py", line 2446, in wsgi_app
    response = self.full_dispatch_request()
  File "/env/lib/python3.6/site-packages/flask/app.py", line 1951, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/env/lib/python3.6/site-packages/flask/app.py", line 1820, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/env/lib/python3.6/site-packages/flask/_compat.py", line 39, in reraise
    raise value
  File "/env/lib/python3.6/site-packages/flask/app.py", line 1949, in full_dispatch_request
    rv = self.dispatch_request()
  File "/env/lib/python3.6/site-packages/flask/app.py", line 1935, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/vmagent/app/app/modules/admin/routes.py", line 126, in addStudentClass
    logger.error(
AttributeError: type object 'logger' has no attribute 'error'
```